### PR TITLE
Adds ```collectExtraMetrics```

### DIFF
--- a/src/lib/MonitoringServer.ts
+++ b/src/lib/MonitoringServer.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyInstance } from "fastify";
+import fastify, { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 
 import type { MeteringRecorder } from "./MeteringRecorder";
 import type { Loggerlike } from "./types";
@@ -7,18 +7,27 @@ type MonioringMiddlewareDependencies = {
     server: FastifyInstance;
     meteringRecorder: MeteringRecorder;
     enableDefaultMetrics?: boolean;
+    collectExtraMetrics?: () => Promise<string>;
 };
 
 const assignMonitoringRoutes = ({
     server,
     meteringRecorder,
     enableDefaultMetrics,
+    collectExtraMetrics,
 }: MonioringMiddlewareDependencies) => {
     if (enableDefaultMetrics) {
         meteringRecorder.enableDefaultMetrics();
     }
 
-    server.get("/metrics", async () => meteringRecorder.getPrometheusResponse());
+    server.get("/metrics", async (_: FastifyRequest, reply: FastifyReply) => {
+        const metrics = await meteringRecorder.getPrometheusResponse();
+        if (collectExtraMetrics) {
+            const extraMetrics = await collectExtraMetrics();
+            return reply.type("text/plain").send(metrics + extraMetrics);
+        }
+        return reply.type("text/plain").send(metrics);
+    });
 };
 
 export class MonitoringServer {
@@ -31,6 +40,7 @@ export class MonitoringServer {
         private logger: Loggerlike,
         private enableDefaultMetrics = true,
         private port = 9500,
+        private collectExtraMetrics: () => Promise<string>,
     ) {}
 
     public async start(): Promise<void> {
@@ -39,6 +49,7 @@ export class MonitoringServer {
             server: this.server,
             meteringRecorder: this.recorder,
             enableDefaultMetrics: this.enableDefaultMetrics,
+            collectExtraMetrics: this.collectExtraMetrics,
         });
 
         await new Promise<void>((resolve, reject) =>


### PR DESCRIPTION
adds collectExtraMetrics for appending extra metrics during metric scraping
example:

```ts
        const monitoringServer = new MonitoringServer(meteringRecorder, logger, true, 9500, async () => {
            return 'some_extra_metrics 44 \n some_extra_metric2 312';
        });
```